### PR TITLE
Action targets Node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ outputs:
   deleted_assets:
     description: 'The asset files which deleted when delete the release'
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'package'


### PR DESCRIPTION
Node 20 is now the default version of node for GitHub Actions